### PR TITLE
feat: throws an error when getFilesystemLayers fails

### DIFF
--- a/src/explorer.spec.ts
+++ b/src/explorer.spec.ts
@@ -156,4 +156,24 @@ describe('getFilesystemLayers', () => {
     expect(provider.addFile).not.toHaveBeenCalled();
     expect(provider.addWhiteout).not.toHaveBeenCalled();
   });
+
+  test('when an error happens', async () => {
+    vi.mocked(containerEngine).saveImage.mockRejectedValue(new Error('an error'));
+    await expect(
+      explorer.getFilesystemLayers({
+        engineId: '',
+        engineName: '',
+        Id: 'id',
+        ParentId: 'parentId',
+        RepoTags: [],
+        Created: 1,
+        Size: 1,
+        VirtualSize: 1,
+        SharedSize: 1,
+        Labels: {},
+        Containers: 1,
+        Digest: '',
+      }),
+    ).rejects.toThrowError('Error: an error');
+  });
 });

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -58,8 +58,7 @@ export class Explorer {
       await this.cache.save(image, result);
       return result;
     } catch (e: unknown) {
-      console.error('error extracting image layers', e);
-      return { layers: [] };
+      throw new Error(`error extracting image layers: ${e}`);
     } finally {
       rm(tmpdir, { force: true, recursive: true }).catch((err: unknown) => {
         console.error(`unable to delete directory ${tmpdir}: ${String(err)}`);


### PR DESCRIPTION
Fixes https://github.com/containers/podman-desktop/issues/8213

(depends on #65 for tests to pass)